### PR TITLE
akmd: add seclabel to akmd service

### DIFF
--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -168,6 +168,7 @@ service akmd /system/bin/akmd
     class main
     user compass
     group compass misc input
+    seclabel u:r:akmd:s0
 
 service dhcpcd_bt-pan /system/bin/dhcpcd -BKLG
     disabled


### PR DESCRIPTION
- fixes denials when accessing AK8975Prms.ini

Change-Id: I5bbda662fc9097ed13d66fca055ff20bb1e76afb
